### PR TITLE
Support PVA with p4p

### DIFF
--- a/simulated_server.py
+++ b/simulated_server.py
@@ -1,6 +1,5 @@
-from pcaspy import SimpleServer
 from cheetah.particles import ParticleBeam
-from beamdriver import SimDriver
+from beamdriver import SimDriver, SimServer
 from cheetah.accelerator import Segment 
 import torch
 from utils.load_yaml import load_relevant_controls
@@ -21,13 +20,14 @@ custom_pvs = {'VIRT:BEAM:EMITTANCES': {'type':'float', 'count': 2},
 }
 PVDB.update(custom_pvs)
 pprint.pprint(PVDB)
-server = SimpleServer()
-server.createPV('', PVDB)
-driver = SimDriver(screen=screen_name,
-                   devices=devices,
-                   design_incoming_beam=design_incoming_beam,
-                   lattice_file=lcls_lattice)
+server = SimServer(PVDB)
+driver = SimDriver(
+    server=server,
+    screen=screen_name,
+    devices=devices,
+    design_incoming_beam=design_incoming_beam,
+    lattice_file=lcls_lattice
+)
 
 print('Starting simulated server')
-while True:
-    server.process(0.1)
+server.run()

--- a/simulated_server_diag0.py
+++ b/simulated_server_diag0.py
@@ -1,6 +1,5 @@
-from pcaspy import SimpleServer
 from cheetah.particles import ParticleBeam
-from beamdriver import SimDriver
+from beamdriver import SimDriver, SimServer
 from cheetah.accelerator import Segment 
 import torch
 from utils.load_yaml import load_relevant_controls
@@ -35,13 +34,14 @@ custom_pvs = {'VIRT:BEAM:EMITTANCES': {'type':'float', 'count': 2},
 PVDB.update(custom_pvs)
 pprint.pprint(PVDB)
 
-server = SimpleServer()
-server.createPV('', PVDB)
-driver = SimDriver(screen=screen_name,
-                   devices=devices,
-                   particle_beam=incoming_beam,
-                   lattice_file="lattices/diag0.json") #check that lattice file is actually real..
+server = SimServer(PVDB)
+driver = SimDriver(
+    server=server,
+    screen=screen_name,
+    devices=devices,
+    particle_beam=incoming_beam,
+    lattice_file="lattices/diag0.json" # check that lattice file is actually real..
+)
 
 print('Starting simulated server')
-while True:
-    server.process(0.1)
+server.run()

--- a/utils/pvdb.py
+++ b/utils/pvdb.py
@@ -31,7 +31,9 @@ def create_pvdb(device: dict, **default_params) -> dict:
             screen_params = {
                 get_pv('image'): {
                     'type': 'float',
-                    'count': n_row * n_col
+                    'count': n_row * n_col,
+                    'n_row': n_row,
+                    'n_col': n_col,
                 },
                 get_pv('n_row'): {
                     'type': 'int',

--- a/yaml_configs/environment.yml
+++ b/yaml_configs/environment.yml
@@ -18,3 +18,4 @@ dependencies:
   - pip:
     - git+https://github.com/slaclab/ml-tto
     - git+https://github.com/desy-ml/cheetah
+    - p4p


### PR DESCRIPTION
This allows it to serve PVs with PVA in addition to CA. I tried to roughly emulate the behavior of a real IOC running with Qsrv.

Notes:
- `NTEnum`'s wrap/unwrap don't seem to work too well. I'm not able to get it to properly wrap anything except the dict passed in as the initial value, so I opted to avoid emulating the behavior of mbbo/mbbi.
- There's no way to listen for pvget with p4p, so we have to update the model outputs on `put` instead. This should be OK because (afaik) there are no time-based outputs on the model (i.e. anything that changes read-to-read), with the only caveat being a spike in CPU usage when `put`'ing