### PR TITLE
Expose control and display PVs via CA and PVA

### DIFF
--- a/beamdriver.py
+++ b/beamdriver.py
@@ -20,8 +20,10 @@ class SimServer(SimpleServer):
     PV_ASSOC = {
         'HOPR': 'display.limitHigh',
         'LOPR': 'display.limitLow',
+        'DRVH': 'control.limitHigh',
+        'DRVL': 'control.limitLow',
         'DESC': 'display.description',
-        'EGU': 'display.units'
+        'EGU': 'display.units',
     }
 
     DB_TO_PV = {
@@ -30,6 +32,8 @@ class SimServer(SimpleServer):
         'lopr': 'LOPR',
         'hopr': 'HOPR',
         'prec': 'PREC',
+        'drvh': 'DRVH',
+        'drvl': 'DRVL'
     }
 
     class UpdateHandler:
@@ -74,6 +78,8 @@ class SimServer(SimpleServer):
 
         # Create PVA PVs
         for k, v in pvdb.items():
+            if k.rfind('.') != -1:
+                continue
             self._pva.update(self._build_pv(f'{prefix}{k}', v))
 
         super().__init__()
@@ -548,6 +554,10 @@ class SimDriver(Driver):
         #TODO: need logic for which screen is in and out, maybe if self.screen is out and other screen is in change
         # self.screen
 
+        # For non-simulated PVs, read the value directly
+        if reason.rfind('.') != -1:
+            return self.getParam(reason)
+
         print(f' in read with {reason}')
         if 'Image:ArrayData' in reason and reason.rsplit(':',2)[0] == self.screen:
             print('reading screen')
@@ -600,7 +610,7 @@ class SimDriver(Driver):
             madname = self.devices[screen]["madname"]
             position = self.move_screen(madname)
         elif 'OTRS' in reason and 'PNEUMATIC' not in reason:
-            print(f"""Write to OTRS pvs is disabled, 
+            print(f"""Write to OTRS pvs is disabled,
                   failed to write to {reason}""")
         elif 'TCAV' in reason and 'AREQ' in reason:
             tcav_name = reason.rsplit(':',1)[0]

--- a/utils/pvdb.py
+++ b/utils/pvdb.py
@@ -12,17 +12,27 @@ def create_pvdb(device: dict, **default_params) -> dict:
 
         if 'QUAD' in key:
             quad_params = {
-                get_pv('bact'): {'value': 0.0, 'prec': 5, 'hopr': 20, 'lopr': -20},
-                get_pv('bctrl'): {'value': 0.0, 'prec': 5, 'hopr': 20, 'lopr': -20},
-                get_pv('bmax'): {'value': 20.0, 'prec': 5},
-                get_pv('bmin'): {'value': -20.0, 'prec': 5},
-                get_pv('bdes'): {'value': 0.0, 'prec': 5, 'hopr': 20, 'lopr': -20},
-                get_pv('bcon'): {'value': 0.0, 'prec': 5, 'hopr': 20, 'lopr': -20},
+                get_pv('bact'): {'type': 'float', 'value': 0.0, 'prec': 5, 'hopr': 20, 'lopr': -20, 'drvh': 20, 'drvl': -20},
+                get_pv('bctrl'): {'type': 'float', 'value': 0.0, 'prec': 5, 'hopr': 20, 'lopr': -20, 'drvh': 20, 'drvl': -20},
+                get_pv('bmax'): {'type': 'float', 'value': 20.0, 'prec': 5},
+                get_pv('bmin'): {'type': 'float', 'value': -20.0, 'prec': 5},
+                get_pv('bdes'): {'type': 'float', 'value': 0.0, 'prec': 5, 'hopr': 20, 'lopr': -20, 'drvh': 20, 'drvl': -20},
+                get_pv('bcon'): {'type': 'float', 'value': 0.0, 'prec': 5, 'hopr': 20, 'lopr': -20, 'drvh': 20, 'drvl': -20},
                 get_pv('ctrl'): {
                     'type': 'enum',
                     'enums': ['Ready', 'TRIM', 'Perturb', 'MORE_IF_NEEDED']
                 }
             }
+
+            # Create DRVL/DRVH/HOPR/LOPR PVs, since pcaspy doesn't do that for us.
+            new_pvs = {}
+            for k, v in quad_params.items():
+                for parm, val in v.items():
+                    if parm in ['type', 'value']:
+                        continue
+                    new_pvs[f'{k}.{parm.upper()}'] = {'type': 'float', 'value': val}
+            quad_params.update(new_pvs)
+
             pvdb.update(quad_params)
 
         elif 'OTRS' in key:


### PR DESCRIPTION
Previously we were only exposing a couple display PVs and only for PVA

pcaspy requires that we emulate this behavior ourselves

This fix is required to make Linac-Simulation-Server compatible with the latest Badger interface changes.