### PR TITLE
Linked lcls-tools yaml configs to the simulation server

### DIFF
--- a/env_vars.sh
+++ b/env_vars.sh
@@ -11,3 +11,6 @@ export EPICS_CA_MAX_ARRAY_BYTES=80000000
 export EPICS_PVA_SERVER_PORT=10415
 export EPICS_PVA_ADDR_LIST=127.0.0.1
 export EPICS_PVA_AUTO_ADDR_LIST=YES
+
+#Setup lattice environment variables
+export LCLS_LATTICE=/sdf/group/ad/sw/scm/repos/optics/lcls-lattice

--- a/run.py
+++ b/run.py
@@ -6,34 +6,30 @@ from simulation_server.utils.load_yaml import load_relevant_controls
 from simulation_server.utils.pvdb import create_pvdb
 from simulation_server.beamdriver import SimDriver, SimServer
 from simulation_server.factory import get_virtual_accelerator
-
-FILEPATH = pathlib.Path(__file__).parent.resolve()
-
-
+import lcls_tools.common.devices.yaml as yaml_directory
+import pprint
+FILEPATH= pathlib.Path(yaml_directory.__file__).parent.resolve()
+print(FILEPATH)
 def run_simulation_server(name, monitor_overview, measurement_noise_level):
     if name == "diag0":
         devices = load_relevant_controls(
-            os.path.join(FILEPATH, "simulation_server", "yaml_configs", "DIAG0.yaml")
+            os.path.join( FILEPATH, "DIAG0.yaml")
         )
 
     elif name == "nc_injector":
         devices = load_relevant_controls(
-            os.path.join(
-                FILEPATH, "simulation_server", "yaml_configs", "DL1_2_OTR2.yaml"
-            )
+            os.path.join( FILEPATH, "DL1_2_OTR2.yaml")
         )
     else:
         raise ValueError(f"Unknown virtual accelerator name: {name}")
 
     PVDB = create_pvdb(devices)
-
     va = get_virtual_accelerator(name, monitor_overview, measurement_noise_level)
     server = SimServer(PVDB)
     driver = SimDriver(server=server, devices=devices, virtual_accelerator=va)
 
     print("Starting simulated server")
     server.run()
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run the simulation server.")
@@ -46,8 +42,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--monitor_overview",
-        action="store_true",
-        help="If set, print out an overview plot of the accelerator simulation each time a PV is changed.",
+        type=bool,
+        default=False,
+        help="Print out an overview plot of the accelerator simulation each time a PV is changed.",
     )
     parser.add_argument(
         "--measurement_noise_level",

--- a/run.py
+++ b/run.py
@@ -9,7 +9,7 @@ from simulation_server.factory import get_virtual_accelerator
 import lcls_tools.common.devices.yaml as yaml_directory
 import pprint
 FILEPATH= pathlib.Path(yaml_directory.__file__).parent.resolve()
-print(FILEPATH)
+FP= pathlib.Path(__file__).parent.resolve()
 def run_simulation_server(name, monitor_overview, measurement_noise_level):
     if name == "diag0":
         devices = load_relevant_controls(
@@ -18,7 +18,7 @@ def run_simulation_server(name, monitor_overview, measurement_noise_level):
 
     elif name == "nc_injector":
         devices = load_relevant_controls(
-            os.path.join( FILEPATH, "DL1_2_OTR2.yaml")
+            os.path.join(FP,"simulation_server","yaml_configs", "DL1_2_OTR2.yaml")
         )
     else:
         raise ValueError(f"Unknown virtual accelerator name: {name}")

--- a/simulation_server/factory.py
+++ b/simulation_server/factory.py
@@ -7,6 +7,7 @@ from cheetah.particles import ParticleBeam
 from simulation_server.virtual_accelerator import VirtualAccelerator
 
 FILEPATH = pathlib.Path(__file__).parent.resolve()
+#LCLS_LATTICE = pathlib.Path(os.environ["LCLS_LATTICE"])
 
 
 def get_virtual_accelerator(name, monitor_overview=False, measurement_noise_level=None):
@@ -46,7 +47,8 @@ def get_virtual_accelerator(name, monitor_overview=False, measurement_noise_leve
         )
 
         mapping_file = os.path.join(FILEPATH, "mappings", "lcls_elements.csv")
-        lattice_file = os.path.join(FILEPATH, "lattices", "new_diag0.json")
+        lattice_file= os.path.join(FILEPATH, "lattices", "new_diag0.json")
+        #lattice_file = os.path.join(LCLS_LATTICE, "cheetah", "diag0bpm.json")
 
     elif name == "nc_injector":
         incoming_beam = ParticleBeam.from_openpmd_file(
@@ -58,6 +60,7 @@ def get_virtual_accelerator(name, monitor_overview=False, measurement_noise_leve
 
         mapping_file = os.path.join(FILEPATH, "mappings", "lcls_elements.csv")
         lattice_file = os.path.join(FILEPATH, "lattices", "lcls_cu_segment_otr2.json")
+        #lattice_file = os.path.join(LCLS_LATTICE, "cheetah", "lcls_cu.json")
 
     return VirtualAccelerator(
         lattice_file=lattice_file,

--- a/start.sh
+++ b/start.sh
@@ -1,20 +1,18 @@
 #!/usr/bin/env bash
 
-set -e
-
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# If the particle distribution has not been extracted, extract it now
-[ ! -f h5/impact_inj_output_YAG03.h5 ] && echo "Extracting YAG03 h5..." && xz -k -d h5/impact_inj_output_YAG03.h5.xz
-
-# Get into the rhel7 env
-if [ -f /afs/slac/g/lcls/package/anaconda/envs/rhel7_devel/bin/activate ]; then
-	source /afs/slac/g/lcls/package/anaconda/envs/rhel7_devel/bin/activate
-fi
-
+#  Activate the conda environment from environment.yml
+conda activate linac-simulation || (echo "Could not activate conda environment 'linac-simulation'. Did you run 'conda env create -f environment.yml'?" && exit 1)
 # Setup epics vars
-source epics-env.sh
+source env_vars.sh
 
-# Start it
+# Check for provided arguments or provide defaults
+NAME="${1:-diag0}"
+OVERVIEW="${2:-False}"
+NOISE="${3:-0.0}"
+
+
+# Start the server
 echo "Starting server..."
-python3 simulated_server.py
+python3 run.py --name $NAME --monitor_overview $OVERVIEW --measurement_noise_level $NOISE


### PR DESCRIPTION
Linked lcls-tools yaml configs to simulation server. Diag0 is operational.
Nc_injector needs adaptations to lattice and is using a custom device yaml.

Edited the start.sh script to source correct conda environment and start the server with default args, the user can also provide args to start.sh