### PR TITLE
 ENH: nc_injector loads from multiple yaml areas

### DIFF
--- a/run.py
+++ b/run.py
@@ -15,15 +15,14 @@ FILEPATH= pathlib.Path(yaml_directory.__file__).parent.resolve()
 def run_simulation_server(name, monitor_overview, measurement_noise_level, threaded):
     if name == "diag0":
         devices = load_relevant_controls(
-            os.path.join( FILEPATH, "DIAG0.yaml")
+            [os.path.join( FILEPATH, "DIAG0.yaml")]
         )
         default_params = default_sc_diag0
 
     elif name in ("nc_injector", 'nc_hxr'):
-        devices = load_relevant_controls(
-            os.path.join( FILEPATH, "DL1.yaml")
-            #os.path.join(FP,"simulation_server","yaml_configs", "DL1.yaml")
-        )
+        rel_areas = ["GUN.yaml", "L0.yaml", "DL1.yaml"]
+        filepaths = [os.path.join( FILEPATH, area) for area in rel_areas]
+        devices = load_relevant_controls(filepaths)
         default_params = default_nc_hxr
 
     else:

--- a/simulation_server/utils/load_yaml.py
+++ b/simulation_server/utils/load_yaml.py
@@ -1,9 +1,108 @@
 import yaml
+import pprint
 
 
-def load_relevant_controls(yaml_file):
+def load_yaml(yaml_file: str)-> dict:
     with open(yaml_file, "r") as file:
         data = yaml.safe_load(file)
+    return data
+
+def deep_merge(a: dict, b: dict ) -> dict:
+    """
+    Recursively merge dictionary ``b`` into dictionary ``a``.
+
+    For each key in ``b``:
+      - If the key does not exist in ``a``, it is added.
+      - If the key exists in both ``a`` and ``b`` and both values are dictionaries,
+        the values are merged recursively.
+      - Otherwise, the value from ``b`` replaces the value in ``a``.
+
+    The merge is performed **in place** on ``a``.
+
+    Parameters
+    ----------
+    a : dict
+        Base dictionary to be updated. This dictionary is mutated in place.
+    b : dict
+        Dictionary whose values override or extend those in ``a``.
+
+    Returns
+    -------
+    dict
+        The updated dictionary ``a``.
+
+    Notes
+    -----
+    - Non-dictionary values (e.g., lists, numbers, strings) are replaced, not merged.
+    - Lists are not appended or merged by default.
+    - No type coercion or validation is performed.
+    - Later values always take precedence over earlier ones.
+
+    Examples
+    --------
+    >>> base = {"a": {"x": 1, "y": 2}}
+    >>> override = {"a": {"y": 3, "z": 4}}
+    >>> deep_merge(base, override)
+    {'a': {'x': 1, 'y': 3, 'z': 4}}
+    """
+        
+    for k, v in b.items():
+        if k in a and isinstance(a[k], dict) and isinstance(v, dict):
+            deep_merge(a[k],v)
+        else:
+            a[k] = v
+    return a
+
+def load_relevant_controls(yaml_files: list[str]):
+    """
+    Load and aggregate relevant accelerator control definitions from multiple YAML files.
+
+    This function loads a sequence of YAML configuration files, recursively merges their
+    contents, and extracts a subset of device control information for supported device
+    types. The resulting mapping is keyed by each device's control name and includes
+    EPICS PV definitions, metadata, and a lowercase MAD-compatible device name.
+
+    Supported devices and selection criteria:
+      - Magnets: devices with metadata type ``"QUAD"``
+      - Screens: devices with metadata type ``"PROF"``
+      - Transverse cavities: devices with metadata type ``"LCAV"``
+      - Beam position monitors: devices with metadata type ``"BPM"``
+
+    Parameters
+    ----------
+    yaml_files : list[str]
+        List of paths to YAML configuration files. Files are loaded in order, and later
+        files override or extend earlier ones via a deep merge.
+
+    Returns
+    -------
+    dict
+        Dictionary mapping control names to control definitions. Each entry contains:
+          - ``"pvs"``: EPICS PV definitions from ``controls_information["PVs"]``
+          - ``"metadata"``: Device metadata dictionary
+          - ``"madname"``: Lowercase device name suitable for MAD / lattice usage
+
+    Notes
+    -----
+    - YAML files are merged using a recursive, last-write-wins strategy.
+    - The function assumes a consistent YAML schema for all device entries.
+    - Devices not matching the supported metadata types are ignored.
+    - No validation is performed beyond key lookups; schema validation should be
+      handled upstream (e.g., via Pydantic models).
+
+    Examples
+    --------
+    >>> controls = load_relevant_controls(["base.yaml", "injector.yaml"])
+    >>> controls["QUAD:IN20:121"]["pvs"]
+    {...}
+    """
+
+    
+    data = {}
+    for yaml_file in yaml_files:
+        contents = load_yaml(yaml_file)
+        data = deep_merge(data, contents)
+
     relevant_controls = {}
     # Process magnets
     for name, info in data.get("magnets", {}).items():


### PR DESCRIPTION
I created a change to the utility function that loads yamls. Instead of receiving a string it receives a list of strings that are file filepaths. For each filepath the contents of the file are loaded into a dictionary and merged with previous contents.

By doing this I was able to make nc_injector source pvs from the areas, GUN, L0, and DL1. 